### PR TITLE
Consider all sponsors that created their sponsor.yaml to be active

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -81,10 +81,7 @@ class User:
 
     @cached_property
     def human_name(self):
-        try:
-            return self.bz.getuser(self.fas.bugzilla_email).real_name
-        except xmlrpc.client.Fault:
-            return None
+        return self.fas.human_name
 
     @cached_property
     def sponsor_config(self):


### PR DESCRIPTION
See #13

I don't see this as a solution for that issue because IMHO
`find_directly_sponsored` function should have found the
users. However as a workaround, this is a fine solution.